### PR TITLE
docs: lazy.nvim setup includes lazy keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,44 @@
 # before.nvim
+
 ## Purpose
+
 Track edit locations and jump back to them, like [changelist](https://neovim.io/doc/user/motion.html#changelist), but across buffers.
 
 ![peeked](https://github.com/bloznelis/before.nvim/assets/33397865/d7d8c79e-e716-4588-b602-2271fb0bda1e)
 
 ## Installation
-### lazy.nvim
-```lua
-{
-  'bloznelis/before.nvim',
-  config = function()
-    local before = require('before')
-    before.setup()
 
-    vim.keymap.set('n', '<C-h>', before.jump_to_last_edit, {})
-    vim.keymap.set('n', '<C-l>', before.jump_to_next_edit, {})
-  end
+### lazy.nvim
+
+```lua
+return {
+  {
+    "bloznelis/before.nvim",
+    opts = {},
+    keys = {
+      {
+        "<C-h>",
+        mode = { "n" },
+        function()
+          require("before").jump_to_last_edit()
+        end,
+        desc = "Jump to last edit",
+      },
+      {
+        "<C-l>",
+        mode = { "n" },
+        function()
+          require("before").jump_to_next_edit()
+        end,
+        desc = "Jump to next edit",
+      },
+    },
+  },
 }
 ```
 
 ### Configuration
+
 ```lua
 require('before').setup({
   -- How many edit locations to store in memory (default: 10)


### PR DESCRIPTION
This change includes the lazy.nvim default way of defining keybindings. It also makes the keybindings show up using which-key, in case that is used.

This also introduces a way to lazy load the plugin when using lazy.nvim. This means when neovim is started, the plugin is loaded only when any of the specified keys are pressed.

This will probably not have a big impact for most users, but in case tens of plugins are used, it will start to add up.

The old version loaded the plugin eagerly.

---

Note: the return type of the plugin spec can also be defined using `---@type LazySpec`. I chose to leave this out as I think the lua language server setup is a bit unreliable and it might cause confusion.

See here for an example:
 https://github.com/mikavilpas/dotfiles/blob/bd8874eb82bc0fa1c02416569f11a3c57b7a601a/.config/nvim/lua/plugins/before.lua